### PR TITLE
feat: use setup-node and corepack

### DIFF
--- a/.github/workflows/nx-cloud-agents.yml
+++ b/.github/workflows/nx-cloud-agents.yml
@@ -93,13 +93,22 @@ jobs:
         run: |
           echo "name=$([[ -f ./yarn.lock ]] && echo "yarn" || ([[ -f ./pnpm-lock.yaml ]] && echo "pnpm") || echo "npm")" >> $GITHUB_OUTPUT
 
-      # Set node/npm/yarn versions using volta, with optional overrides provided by the consumer
-      - uses: volta-cli/action@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: "${{ inputs.node-version }}"
-          npm-version: "${{ inputs.npm-version }}"
-          yarn-version: "${{ inputs.yarn-version }}"
-          package-json-path: "${{ inputs.working-directory || github.workspace }}/package.json"
+      - run: corepack enable
+      - run: corepack prepare npm@"${{ inputs.npm-version || 'latest' }}" --activate
+        if: steps.package_manager.outputs.name == 'npm'
+      # default to yarn classic as @stable would be yarn berry
+      - run: corepack prepare yarn@"${{ inputs.yarn-version || '1' }}" --activate
+        if: steps.package_manager.outputs.name == 'yarn'
+      # Set node/npm/yarn versions using volta, with optional overrides provided by the consumer
+      # - uses: volta-cli/action@v4
+      #   with:
+      #     node-version: "${{ inputs.node-version }}"
+      #     npm-version: "${{ inputs.npm-version }}"
+      #     yarn-version: "${{ inputs.yarn-version }}"
+      #     package-json-path: "${{ inputs.working-directory || github.workspace }}/package.json"
 
       # Install pnpm with exact version provided by consumer or fallback to latest
       - name: Install PNPM

--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -117,13 +117,23 @@ jobs:
         run: |
           echo "name=$([[ -f ./yarn.lock ]] && echo "yarn" || ([[ -f ./pnpm-lock.yaml ]] && echo "pnpm") || echo "npm")" >> $GITHUB_OUTPUT
 
-      # Set node/npm/yarn versions using volta, with optional overrides provided by the consumer
-      - uses: volta-cli/action@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: "${{ inputs.node-version }}"
-          npm-version: "${{ inputs.npm-version }}"
-          yarn-version: "${{ inputs.yarn-version }}"
-          package-json-path: "${{ inputs.working-directory || github.workspace }}/package.json"
+      - run: corepack enable
+      - run: corepack prepare npm@"${{ inputs.npm-version || 'latest' }}" --activate
+        if: steps.package_manager.outputs.name == 'npm'
+       # default to yarn classic for now. @stable would be yarn berry
+      - run: corepack prepare yarn@"${{ inputs.yarn-version || '1' }}" --activate
+        if: steps.package_manager.outputs.name == 'yarn'
+
+      # # Set node/npm/yarn versions using volta, with optional overrides provided by the consumer
+      # - uses: volta-cli/action@v4
+      #   with:
+      #     node-version: "${{ inputs.node-version }}"
+      #     npm-version: "${{ inputs.npm-version }}"
+      #     yarn-version: "${{ inputs.yarn-version }}"
+      #     package-json-path: "${{ inputs.working-directory || github.workspace }}/package.json"
 
       # Install pnpm with exact version provided by consumer or fallback to latest
       - name: Install PNPM


### PR DESCRIPTION
volta-cli/action is flaky causing issues with people running pipelines in ci

instead switch out volta-cli/action and use actions/setup-node and corepack 
